### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
## What changed

- Upgraded `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` to their current Node.js 24-based major versions.
- Preserved the existing Node and pnpm versions, cache settings, triggers, and build commands.

## Why

GitHub now warns when older JavaScript action runtimes are forced onto Node.js 24. Updating the action majors removes the deprecated runtime path.

## Validation

- `actionlint` 1.7.12
- YAML parsing
- `git diff --check`
- Verified each selected action major declares `using: node24`